### PR TITLE
driver: nwl-dsi: remove lanes check

### DIFF
--- a/drivers/gpu/drm/bridge/nwl-dsi.c
+++ b/drivers/gpu/drm/bridge/nwl-dsi.c
@@ -1204,8 +1204,9 @@ static int nwl_dsi_bridge_atomic_check(struct drm_bridge *bridge,
 
 	DRM_DEV_DEBUG_DRIVER(dsi->dev, "lanes=%u, data_rate=%lu\n",
 			     config->lanes, config->bitclock);
-	if (config->lanes < 2 || config->lanes > 4)
-		return -EINVAL;
+	/* UMOH is using 1 lane only */
+	//if (config->lanes < 2 || config->lanes > 4)
+	//	return -EINVAL;
 
 	/* Max data rate for this controller is 1.5Gbps */
 	if (config->bitclock > 1500000000)


### PR DESCRIPTION
Remove lanes number check less than 2. UMOH uses only 1 lane and this check mades driver unusable with UMOH panel